### PR TITLE
Remove system-ui font from default font

### DIFF
--- a/sass/constants.scss
+++ b/sass/constants.scss
@@ -39,7 +39,7 @@ $columns: (
 );
 
 // Fonts
-$font-sans: -apple-system, system-ui, BlinkMacSystemFont, "Segoe UI", Roboto, Ubuntu, "Noto Sans", "Helvetica Neue", Arial, sans-serif;
+$font-sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 $font-serif: Georgia, Cambria, "Times New Roman", Times, serif;
 $font-monospace: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
 


### PR DESCRIPTION
The `system-ui` font has some issues on Windows. This PR removes this font from the list of fonts defined in `$font-sans`.

Reference: https://infinnie.github.io/blog/2017/systemui.html