### PR TITLE
Fix line-height property in label component

### DIFF
--- a/sass/components/label.scss
+++ b/sass/components/label.scss
@@ -9,6 +9,7 @@
             "align-items": center,
             "display": flex,
             "font-size": 0.857rem,
+            "line-height": normal,
             "min-width": 0px,
             "width": 100%,
         ),


### PR DESCRIPTION
This PR sets the `line-height` property of the label component to `normal`.