### PR TITLE
Add Toggler component

### DIFF
--- a/docs/components/toggler.mdx
+++ b/docs/components/toggler.mdx
@@ -1,0 +1,29 @@
+---
+title: "Toggler"
+---
+
+# Toggler
+
+Use the `siimple-toggler` class to create a toggle button, useful for displaying hidden menus:
+
+```html align=center live=true
+<button class="siimple-toggler"></button>
+```
+
+
+### Variants
+
+Variants for this component can be defined in the `button.toggler` section of the variants configuration:
+
+```scss
+@include siimple.configure(
+    $variants: (
+        "button.toggler": (
+            "default": (
+                "border-color": currentColor,
+                "color": currentColor,
+            ),
+        ),
+    ),
+);
+```

--- a/sass/components/toggler.scss
+++ b/sass/components/toggler.scss
@@ -1,0 +1,51 @@
+@use "../plugins.scss" as plugins;
+@use "../utils.scss" as utils;
+
+// @description Toggler button
+@function plugin-toggler() {
+    @return plugins.create-component-plugin((
+        "id": "button.toggler",
+        "name": "toggler",
+        "styles": (
+            "appearance": none,
+            "background-color": transparent,
+            "border-color": currentColor,
+            "border-radius": "normal",
+            "border-style": solid,
+            "border-width": 0.125rem,
+            "color": currentColor,
+            "cursor": pointer,
+            "display": block,
+            "height": 2.5rem,
+            "opacity": 0.8,
+            "padding-left": 0.75rem,
+            "padding-right": 0.75rem,
+            "position": relative,
+            "width": 3rem,
+            "z-index": 400,
+            "&:hover": (
+                "opacity": 1.0,
+            ),
+            "&::before": (
+                "border-top": 0.25rem solid currentColor,
+                "border-bottom": 0.25rem solid currentColor,
+                "content": "''",
+                "height": 1.25rem,
+                "left": 0.5rem,
+                "position": absolute,
+                "width": 1.75rem,
+                "top": 0.5rem,
+            ),
+            "&::after": (
+                "background-color": currentColor,
+                "content": "''",
+                "height": 0.25rem,
+                "left": 0.5rem,
+                "position": absolute,
+                "width": 1.75rem,
+                "top": 1rem,
+            ),
+        ),
+        "variants": utils.empty-map(),
+    ));
+}

--- a/sass/plugins/components.scss
+++ b/sass/plugins/components.scss
@@ -27,5 +27,6 @@
         plugin-text(),
         plugin-textarea(),
         plugin-title(),
+        plugin-toggler(),
     ));
 }

--- a/src/components/CheatSheet.js
+++ b/src/components/CheatSheet.js
@@ -250,6 +250,10 @@ export const CheatSheet = props => {
                     </div>
                 ))}
             </Section>
+            {/* Toggler example */}
+            <Section title="Toggler">
+                <button className="siimple-toggler" />
+            </Section>
             {/* Modal and scrim example */}
             <Section title="Modal">
                 <div align="center" className="has-mb-4">

--- a/src/navs/documentation.js
+++ b/src/navs/documentation.js
@@ -29,6 +29,7 @@ export const documentationNav = [
     {"group": "components", "url": "/components/text", "label": "Text"},
     {"group": "components", "url": "/components/textarea", "label": "Textarea"},
     {"group": "components", "url": "/components/title", "label": "Title"},
+    {"group": "components", "url": "/components/toggler", "label": "Toggler"},
     {"group": "experiments", "url": "/experiments/modal", "label": "Modal"},
     {"group": "experiments", "url": "/experiments/progress", "label": "Progress"},
     {"group": "experiments", "url": "/experiments/scrim", "label": "Scrim"},


### PR DESCRIPTION
This PR adds a new component called **Toggler**, that allows to create a menu toggle button, useful for displaying hidden menus:

![image](https://user-images.githubusercontent.com/5751201/152038866-1d228562-18ca-4388-8cb0-4c0834cc4d9c.png)

- [X] Created component in `sass/components` folder.
- [X] Registered as a new component in `sass/plugins/components.scss`.
- [X] Added to cheatsheet.
- [X] Add documentation page.