### PR TITLE
Fix border-radius in toggler component

### DIFF
--- a/sass/components/toggler.scss
+++ b/sass/components/toggler.scss
@@ -10,7 +10,7 @@
             "appearance": none,
             "background-color": transparent,
             "border-color": currentColor,
-            "border-radius": "normal",
+            "border-radius": 0.5rem,
             "border-style": solid,
             "border-width": 0.125rem,
             "color": currentColor,


### PR DESCRIPTION
This PR fixes the wrong `border-radius` property of the toggler component.