### PR TITLE
Allow generating dynamic breakpoints using template selectors

### DIFF
--- a/sass/sheet.scss
+++ b/sass/sheet.scss
@@ -64,10 +64,18 @@
 }
 
 // @description Build styles
-@mixin build-styles($styles) {
+@mixin build-styles($styles, $vars: utils.empty-map()) {
     @each $selector,$rules in $styles {
+        // Check for all breakpoints selector
+        @if utils.starts-with($selector, "@breakpoints") {
+            @include breakpoints.use-breakpoints() using ($breakpont) {
+                @include build-styles($rules, (
+                    "breakpoint": $breakpoint,
+                ));
+            }
+        }
         // Check for breakpoint selector
-        @if breakpoints.is-breakpoint-selector($selector) {
+        @else if breakpoints.is-breakpoint-selector($selector) {
             $breakpoint: breakpoints.get-breakpoint-from-selector($selector);
             @include breakpoints.use-breakpoint($breakpoint) {
                 @include build-styles($rules);
@@ -81,7 +89,8 @@
         }
         // If is not a media rule, add each rule
         @else if not utils.starts-with($selector, "@") {
-            #{utils.unquote($selector)} {
+            $parsed-selector: utils.template($selector, $vars);
+            #{utils.unquote($parsed-selector)} {
                 @include build-rules($rules)
             }
         }

--- a/sass/utils.scss
+++ b/sass/utils.scss
@@ -228,6 +228,16 @@
     @return $str;
 }
 
+// @description template substitution in string
+@function template($str: "", $vars: null, $start: "{{", $end: "}}") {
+    @if is-map($vars) {
+        @each $key,$value in $vars {
+            $str: replace($str, $start + $key + $end, $value);
+        }
+    }
+    @return $str;
+}
+
 // Secure string unquote
 // This method will check first if the provided value is a string
 @function unquote($str) {


### PR DESCRIPTION
This PR allow to dynamically generate styles for all breakpoints using template selectors. So now, we can use the following syntax:

```scss
@include siimple.configure((
    $styles: (
        "@breakpoints": (
            ".half-{{breakpoint}}": (
                "width": 50%,
            ),
        ),
    ),
));
```

This will generate:

```css
@media screen and (max-width: 600px) {
    .half-mobile {
        width: 50%;
    }
}
@media screen and (min-width: 600px) {
    .half-tablet {
        width: 50%;
    }
}
/* ... */
```