### PR TITLE
Fix content component sizes

### DIFF
--- a/sass/components/content.scss
+++ b/sass/components/content.scss
@@ -7,8 +7,8 @@ $content-default-sizes: (
     "small":  "608px",    //--> 560px
     "medium": "768px",    //--> 720px
     "large":  "1008px",   //--> 960px
-    "xlarge": "1188px",   //--> 1140px
-    "huge":   "1328px",   //--> 1280px
+    "xlarge": "1200px",   //--> 1152px
+    "huge":   "1360px",   //--> 1312px
 );
 
 // Generate content component configuration


### PR DESCRIPTION
This PR fixes the `xlarge` and `huge` sizes of the `content` component.