### PR TITLE
Update breakpoints and content sizes

### DIFF
--- a/docs/components/content.mdx
+++ b/docs/components/content.mdx
@@ -14,21 +14,19 @@ A **content** is a layout component that divides your website in section and pla
 </div>
 ```
 
-By default the container has the maximun width minus the `24px` of padding left and right. You can change the width of the content element using one of the following sizing variants:
+By default the container has the maximun width minus the `32px` of padding left and right. You can change the width of the content element using one of the following sizing variants:
 
 | Variant | Description |
 |:------|:------------|
-| `small` | It will have a maximum width of `560px`. |
-| `medium` | It will have a maximum width of `720px`. |
-| `large` | It will have a maximum width of `960px`. |
-| `xlarge` | It will have a maximum width of `1140px`. |
-| `huge` | It will have a maximum width of `1280px`. |
+| `tablet` | It will have a maximum width of `640px`. |
+| `desktop` | It will have a maximum width of `1264px`. |
+| `widescreen` | It will have a maximum width of `1504px`. |
 
 On screens with sizes lower than the specified in the sizing modifier, the container will have the maximun width.
 
 ```html
-<div class="content is-medium">
-    Max 768px container
+<div class="content is-tablet">
+    Max 640px container
 </div>
 ```
 

--- a/docs/responsive.mdx
+++ b/docs/responsive.mdx
@@ -13,10 +13,10 @@ By default, we provide four screen breakpoints:
 
 | Prefix | Description | CSS media query |
 |--------|-------------|-----------------|
-| mobile | Applied to screen sizes up to `599px`. | `@media (max-width: 599px)` |
-| tablet | Applied to screen sizes from `600px`. | `@media (min-width: 600px)` |
-| desktop | Applied to screen sizes from `1200px`. | `@media (min-width: 1200px)` |
-| fullhd | Applied to screen sizes from `1800px`. | `@media (min-width: 1800px)` |
+| mobile | Applied to screen sizes up to `639px`. | `@media (max-width: 639px)` |
+| tablet | Applied to screen sizes from `640px`. | `@media (min-width: 640px)` |
+| desktop | Applied to screen sizes from `1264px`. | `@media (min-width: 1264px)` |
+| widescreen | Applied to screen sizes from `1504px`. | `@media (min-width: 1504px)` |
 
 
 The following example uses these responsive variants to customize how the card will be displayed for different screen sizes:
@@ -35,4 +35,3 @@ The following example uses these responsive variants to customize how the card w
     </div>
 </div>
 ``` 
-

--- a/sass/breakpoints.scss
+++ b/sass/breakpoints.scss
@@ -5,7 +5,7 @@
 // Breakpoints variables
 $-breakpoints: (
     "mobile": (
-        "min": 0px, 
+        "min": null, 
         "max": constants.$tablet,
     ),
     "tablet": (
@@ -16,8 +16,8 @@ $-breakpoints: (
         "min": constants.$desktop, 
         "max": null,
     ),
-    "fullhd": (
-        "min": constants.$fullhd,
+    "widescreen": (
+        "min": constants.$widescreen,
         "max": null,
     ),
 );

--- a/sass/components.scss
+++ b/sass/components.scss
@@ -1,3 +1,4 @@
+@use "./breakpoints.scss" as breakpoints;
 @use "./constants.scss" as constants;
 @use "./selectors.scss" as selectors;
 @use "./variants.scss" as variants;
@@ -285,22 +286,26 @@ $content-default-sizes: (
 // Generate content component configuration
 @mixin content() {
     // $content-gap: lib.get-in($options, "gap", 1.5rem);
+    $content-gap: 2rem;
     $content-variants: utils.empty-map();
-    @each $name,$size in $content-default-sizes {
-        $content-media: "@media screen and (min-width: #{$size})";
-        $content-variants: utils.set-in($content-variants, $name, (
-            "#{$content-media}": (
-                "max-width": $size,
-            ),
-        ));
+    @each $name,$values in breakpoints.get-breakpoints() {
+        $min-size: utils.get-in($values, "min", null);
+        @if $min-size not null {
+            $content-media: "@media screen and (min-width: #{$min-size})";
+            $content-variants: utils.set-in($content-variants, $name, (
+                "#{$content-media}": (
+                    "max-width": $min-size,
+                ),
+            ));
+        }
     }
     // Return content component configuration
     @include selectors.use-component-selector("content") {
         display: block;
         margin-left: auto;
         margin-right: auto;
-        padding-left: $content-default-gap;
-        padding-right: $content-default-gap;
+        padding-left: $content-gap;
+        padding-right: $content-gap;
         width: 100%;
         @include variants.use-variants("content", $content-variants);
     };

--- a/sass/constants.scss
+++ b/sass/constants.scss
@@ -1,7 +1,7 @@
 // Screen sizes
-$tablet: 600px;
-$desktop: 1200px;
-$fullhd: 1800px;
+$tablet: 640px; // 576px + 4rem
+$desktop: 1264px; // 1200px + 4rem
+$widescreen: 1504px; // 1440px + 4rem 
 
 // Default colors
 $primary: #1c76fd;     // blue-500

--- a/website/pages/try.mdx
+++ b/website/pages/try.mdx
@@ -1,6 +1,6 @@
 ---
 title: Try siimple
-pageSize: huge
+pageSize: widescreen
 ---
 
 <div className="has-mt-8">

--- a/website/src/components/Footer.js
+++ b/website/src/components/Footer.js
@@ -10,7 +10,7 @@ const FOOTER_LINKS = [
 ];
 
 export const Footer = props => {
-    const size = props.size || "xlarge";
+    const size = props.size || "desktop";
     const items = props.links || FOOTER_LINKS;
     const itemClass ="has-text-coolgray-700 hover:has-text-blue-500 has-text-no-underline";
     return (

--- a/website/src/components/Header.js
+++ b/website/src/components/Header.js
@@ -14,7 +14,7 @@ const HEADER_ITEMS = [
 ];
 
 export const Header = props => {
-    const size = props.size || "xlarge";
+    const size = props.size || "desktop";
     const items = props.items || HEADER_ITEMS;
     const itemClass = kofi.classNames({
         "has-flex has-radius has-opacity-100": true,
@@ -44,5 +44,5 @@ export const Header = props => {
 // Header default props
 Header.defaultProps = {
     items: null,
-    size: "xlarge",
+    size: "desktop",
 };

--- a/website/src/layouts/default.js
+++ b/website/src/layouts/default.js
@@ -7,7 +7,7 @@ import {Seo} from "../components/Seo.js";
 import {shortcodes} from "../markdown.js";
 
 const DefaultLayout = props => {
-    const size = props.pageContext?.frontmatter?.pageSize || props.size || "xlarge";
+    const size = props.pageContext?.frontmatter?.pageSize || props.size || "desktop";
     const title = props.pageContext?.frontmatter?.title || props.title;
     return (
         <React.Fragment>
@@ -26,7 +26,7 @@ const DefaultLayout = props => {
 DefaultLayout.defaultProps = {
     className: "",
     title: "",
-    size: "xlarge",
+    size: "desktop",
 };
 
 export default DefaultLayout;

--- a/website/src/layouts/documentation.js
+++ b/website/src/layouts/documentation.js
@@ -34,7 +34,7 @@ export default props => {
             {/* Header block */}
             <Header />
             {/* Main content */}
-            <div className="content is-xlarge has-pb-10 has-pt-0">
+            <div className="content is-desktop has-pb-10 has-pt-0">
                 <div className="columns has-mb-0">
                     {/* Sidebar wrapper */}
                     <div className="column mobile:is-hidden" style={{"maxWidth":"18rem"}}>


### PR DESCRIPTION
This PR updates the default breakpoints of **siimple**:

- `mobile`: up to `640px` screen sizes.
- `tablet`: for screens from `640px` to `1264px`.
- `desktop`: for screens from `1264px` to `1504px`.
- `widescreen`: for screens from `1504px`.

Also, the `content` component has been updated and now the sizes are generated automatically from breakpoints, so now we will have by default the following classes:

- `content.is-tablet`: will have a maximum width of `640px`.
- `content.is-desktop`: will have a maximum width of `1264px`.
- `content.is-widescreen`: will have a maximum width of `1504px`.
