### PR TITLE
Improve theme scales

### DIFF
--- a/docs/colors.mdx
+++ b/docs/colors.mdx
@@ -19,13 +19,12 @@ import colors from "siimple/colors";
 
 // Comfigure siimple using the color palette
 export default {
-    scales: {
-        colors: {
-            primary: colors.mint["500"],
-            secondary: colors.royal["600"],
-            background: colors.white,
-            text: colors.coolgray["700"],
-        },
+    colors: {
+        primary: colors.mint["500"],
+        secondary: colors.royal["600"],
+        background: colors.white,
+        text: colors.coolgray["700"],
     },
+    // ...other configuration
 };
 ```

--- a/docs/configuration.mdx
+++ b/docs/configuration.mdx
@@ -16,18 +16,16 @@ export default {
     useBorderBox: true,
     useElements: true,
     prefix: "",
-    scales: {
-        colors: {
-            primary: colors.blue["500"],
-            secondary: colors.mint["600"],
-            text: colors.gray["800"],
-            background: "#ffffff",
-        },
-        fonts: {
-            body: ["Roboto", "sans-serif"],
-            heading: ["Montserrat", "sans-serif"],
-            monospace: ["monospace"],
-        },
+    colors: {
+        primary: colors.blue["500"],
+        secondary: colors.mint["600"],
+        text: colors.gray["800"],
+        background: "#ffffff",
+    },
+    fonts: {
+        body: ["Roboto", "sans-serif"],
+        heading: ["Montserrat", "sans-serif"],
+        monospace: ["monospace"],
     },
 };
 ```
@@ -86,31 +84,29 @@ export default {
 };
 ```
 
-### Scales
+### Theme scales
 
-In the `scales` section you can configure the list of CSS properties specific for your project, that includes colors, fonts, sizes, and more!
+You can configure the list of CSS properties specific for your project using the theme scales, that includes colors, fonts, sizes, and more!
 
 ```js title=siimple.config.js
 import colors from "siimple/colors";
 
 export default {
-    scales: {
-        colors: {
-            primary: colors.blue["500"],
-            secondary: colors.mint["600"],
-            text: colors.gray["800"],
-            background: "#ffffff",
-        },
-        fonts: {
-            body: ["Roboto", "sans-serif"],
-            heading: ["Montserrat", "sans-serif"],
-            monospace: ["monospace"],
-        },
+    colors: {
+        primary: colors.blue["500"],
+        secondary: colors.mint["600"],
+        text: colors.gray["800"],
+        background: "#ffffff",
+    },
+    fonts: {
+        body: ["Roboto", "sans-serif"],
+        heading: ["Montserrat", "sans-serif"],
+        monospace: ["monospace"],
     },
 };
 ```
 
-Visit the [scales guide](/scales) to read more about how to define your custom scales.
+Visit the [theme scales guide](/scales) to read more about how to define your custom theme scales.
 
 ### Variants
 

--- a/docs/scales.mdx
+++ b/docs/scales.mdx
@@ -1,10 +1,10 @@
 ---
-title: Scales
+title: Theme Scales
 ---
 
-# Scales
+# Theme Scales
 
-The following scales can be provided in the `scales` section, and are applied to specific CSS properties:
+The following theme scales can be provided in your configuration, and are applied to specific CSS properties:
 
 | Scale | CSS Properties |
 |-------|----------------|
@@ -25,12 +25,10 @@ Scales can be used in styles and variants. Just provide a string with the scale 
 
 ```js title=siimple.config.js
 export default {
-    scales: {
-        fontSizes: {
-            small: "0.875rem",
-            body: "16px",
-            large: "1.5rem",
-        },
+    fontSizes: {
+        small: "0.875rem",
+        body: "16px",
+        large: "1.5rem",
     },
     styles: {
         "h1": {
@@ -45,7 +43,7 @@ export default {
 
 ## Colors
 
-In the `scales.colors` section you can provide your custom color palette. To allow creating interoperable themes for **siimple**, the following colors must be always provided in a color scale:
+In the `colors` section you can provide your custom color palette. To allow creating interoperable themes for **siimple**, the following colors must be always provided in a color scale:
 
 - `primary`: the primary color used in your theme.
 - `secodary`: the secondary color used in your theme.
@@ -54,9 +52,27 @@ In the `scales.colors` section you can provide your custom color palette. To all
 - `background`: color used for the body background.
 - `fill`: background color used in some components like inputs or textarea.
 
+This is the default colors configuration:
+
+```js title=siimple.config.js
+import colors from "siimple/colors";
+
+export default {
+    colors: {
+        primary: colors.blue["500"],
+        secondary: colors.royal["500"],
+        background: colors.white,
+        text: colors.coolgray["700"],
+        heading: colors.coolgray["800"],
+        muted: colors.coolgray["500"],
+        fill: colors.coolgray["200"],
+    },
+};
+```
+
 ## Font family
 
-In the `scales.fonts` section you can define the fonts used in your theme. The following fonts should be always provided: 
+In the `fonts` section you can define the fonts used in your theme. The following fonts should be always provided: 
 
 - `body`: font used for the body text.
 - `heading`: font used in heading elements. 
@@ -66,35 +82,33 @@ This is the list of the default font sizes defined in **siimple**:
 
 ```js title=siimple.config.js
 export default {
-    scales: {
-        fonts: {
-            body: [
-                "-apple-system", 
-                "BlinkMacSystemFont", 
-                "'Segoe UI'", 
-                "Roboto", 
-                "'Helvetica Neue'", 
-                "Arial", 
-                "sans-serif",
-            ],
-            heading: "inherit",
-            monospace: [
-                "SFMono-Regular", 
-                "Menlo", 
-                "Monaco", 
-                "Consolas", 
-                "'Liberation Mono'", 
-                "'Courier New'", 
-                "monospace",
-            ],
-        },
+    fonts: {
+        body: [
+            "-apple-system", 
+            "BlinkMacSystemFont", 
+            "'Segoe UI'", 
+            "Roboto", 
+            "'Helvetica Neue'", 
+            "Arial", 
+            "sans-serif",
+        ],
+        heading: "inherit",
+        monospace: [
+            "SFMono-Regular", 
+            "Menlo", 
+            "Monaco", 
+            "Consolas", 
+            "'Liberation Mono'", 
+            "'Courier New'", 
+            "monospace",
+        ],
     },
 };
 ```
 
 ## Font size
 
-In the `scales.fontSizes` section you can define the font sizes used in your theme. The following sizes should be always provided: 
+In the `fontSizes` section you can define the font sizes used in your theme. The following sizes should be always provided: 
 
 - `body`: font size used in the body text.
 - `small`: font size used in `<small>` elements.
@@ -103,18 +117,16 @@ This is the list of the default font sizes defined in **siimple**:
 
 ```js title=siimple.config.js
 export default {
-    scales: {
-        fontSizes: {
-            small: "0.875rem",
-            body: "16px",
-        },
+    fontSizes: {
+        small: "0.875rem",
+        body: "16px",
     },
 };
 ```
 
 ## Font weight
 
-In the `scales.fontWeights` section you can define the `font-weight` values used in your theme. The following weights should be always provided in a font weights scale map: 
+In the `fontWeights` section you can define the `font-weight` values used in your theme. The following weights should be always provided in a font weights scale map: 
 
 - `body`: font-weight used for the body text.
 - `heading`: font-weight used for heading elements.
@@ -124,19 +136,17 @@ This is the list of the default font weights defined in **siimple**:
 
 ```js title=siimple.config.js
 export default {
-    scales: {
-        fontWeights: {
-            body: "400",
-            heading: "700",
-            bold: "700",
-        },
+    fontWeights: {
+        body: "400",
+        heading: "700",
+        bold: "700",
     },
 };
 ```
 
 ## Line height
 
-In the `scales.lineHeights` section you can define the line heights used in your theme. The following line heights should be always provided:
+In the `lineHeights` section you can define the line heights used in your theme. The following line heights should be always provided:
 
 - `body`: line height used for the body text.
 - `heading`: line height used for headings.
@@ -145,11 +155,9 @@ This is the list of the default line heights defined in **siimple**:
 
 ```js title=siimple.config.js
 export default {
-    scales: {
-        lineHeights: {
-            body: "1.5",
-            heading: "1.125",
-        },
+    lineHeights: {
+        body: "1.5",
+        heading: "1.125",
     },
 };
 ```

--- a/playground/src/actions.js
+++ b/playground/src/actions.js
@@ -22,18 +22,18 @@ export const loadPlayground = content => {
             }
         }
         // Check for data in localStorage
-        else {
-            content.html = localStorage.getItem(htmlSymbol) || content.html;
-            content.config = localStorage.getItem(configSymbol) || content.config;
-        }
+        // else {
+        //     content.html = localStorage.getItem(htmlSymbol) || content.html;
+        //     content.config = localStorage.getItem(configSymbol) || content.config;
+        // }
         return resolve(content);
     });
 };
 
 // Save playground content in local storage
 export const savePlayground = content => {
-    localStorage.setItem(htmlSymbol, content.html || "");
-    localStorage.setItem(configSymbol, content.config || "");
+    // localStorage.setItem(htmlSymbol, content.html || "");
+    // localStorage.setItem(configSymbol, content.config || "");
 };
 
 // Share the playground code via URL

--- a/playground/src/defaults.js
+++ b/playground/src/defaults.js
@@ -18,13 +18,21 @@ export const defaultHtml = `
 
 // Default configuration for playground
 export const defaultConfig = `
-// You can import siimple colors to customize your theme
+// You can import our color palette to create your theme
 // import colors from "siimple/colors";
 
+// You can import presets to extend siimple using reusable styles and themes
+// import markup from "@siimple/preset-markup";
+import reboot from "@siimple/preset-reboot";
+import utilities from "@siimple/preset-utilities";
+import icons from "@siimple/preset-icons";
+
 export default {
-    prefix: "",
-    scales: {},
-    variants: {},
+    styles: {
+        ...reboot.styles,
+        ...utilities.styles,
+        ...icons.styles,
+    },
 };
 
 `.trim();

--- a/playground/src/worker.js
+++ b/playground/src/worker.js
@@ -1,10 +1,18 @@
 import {build, mergeConfig} from "siimple";
 import defaultConfig from "siimple/defaultConfig.js";
 import colors from "siimple/colors.js";
+import reboot from "@siimple/preset-reboot";
+import markup from "@siimple/preset-markup";
+import utilities from "@siimple/preset-utilities";
+import icons from "@siimple/preset-icons";
 
 const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 const modules = {
-    "siimple-colors": colors,
+    colors,
+    reboot,
+    markup,
+    utilities,
+    icons,
 };
 
 let prevConfig = null;
@@ -14,7 +22,8 @@ let prevCss = null;
 const evaluateConfig = configStr => {
     return Promise.resolve().then(() => {
         const configCode = configStr
-            .replace(/import\s*(.*?)\s*from\s*(['"])siimple\/colors(\.js)?\2/g, `const $1 = __require("siimple-colors");`)
+            .replace(/import\s*(.*?)\s*from\s*(['"])siimple\/colors(\.js)?\2/g, `const $1 = __require("colors");`)
+            .replace(/import\s*(.*?)\s*from\s*(['"])@siimple\/preset-(\w)(\.js)?\2/g, `const $1 = __require("$3");`)
             .replace(/export default /, "return ");
         
         // Custom require function

--- a/playground/src/worker.js
+++ b/playground/src/worker.js
@@ -22,8 +22,8 @@ let prevCss = null;
 const evaluateConfig = configStr => {
     return Promise.resolve().then(() => {
         const configCode = configStr
-            .replace(/import\s*(.*?)\s*from\s*(['"])siimple\/colors(\.js)?\2/g, `const $1 = __require("colors");`)
-            .replace(/import\s*(.*?)\s*from\s*(['"])@siimple\/preset-(\w)(\.js)?\2/g, `const $1 = __require("$3");`)
+            .replace(/import\s*(.*?)\s*from\s*(['"])siimple\/colors(\.js)?\2(;)?/g, `const $1 = __require("colors");`)
+            .replace(/import\s*(.*?)\s*from\s*(['"])@siimple\/preset-(.*?)(\.js)?\2(;)?/g, `const $1 = __require("$3");`)
             .replace(/export default /, "return ");
         
         // Custom require function

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -20,6 +20,10 @@ module.exports = {
         ],
         alias: {
             "siimple": path.resolve(__dirname, "../siimple/"),
+            "@siimple/preset-reboot": path.resolve(__dirname, "../presets/reboot/"),
+            "@siimple/preset-markup": path.resolve(__dirname, "../presets/markup/"),
+            "@siimple/preset-utilities": path.resolve(__dirname, "../presets/utilities/"),
+            "@siimple/preset-icons": path.resolve(__dirname, "../presets/icons/"),
         },
     },
     module: {

--- a/siimple/defaultConfig.js
+++ b/siimple/defaultConfig.js
@@ -25,35 +25,33 @@ export default {
         },
     },
     // Default theme scales
-    scales: {
-        colors: {
-            primary: colors.blue["500"],
-            secondary: colors.royal["500"],
-            background: colors.white,
-            text: colors.coolgray["700"],
-            heading: colors.coolgray["800"],
-            muted: colors.coolgray["500"],
-            fill: colors.coolgray["200"],
-        },
-        fonts: {
-            body: fonts.sans,
-            heading: "inherit",
-            monospace: fonts.mono,
-        },
-        fontSizes: {
-            small: fontSizes["sm"],
-            body: "16px",
-            large: fontSizes["lg"],
-        },
-        fontWeights: {
-            body: "400",
-            heading: "700",
-            bold: "700",
-        },
-        lineHeights: {
-            heading: lineHeights.tight,
-            body: lineHeights.normal,
-        },
+    colors: {
+        primary: colors.blue["500"],
+        secondary: colors.royal["500"],
+        background: colors.white,
+        text: colors.coolgray["700"],
+        heading: colors.coolgray["800"],
+        muted: colors.coolgray["500"],
+        fill: colors.coolgray["200"],
+    },
+    fonts: {
+        body: fonts.sans,
+        heading: "inherit",
+        monospace: fonts.mono,
+    },
+    fontSizes: {
+        small: fontSizes["sm"],
+        body: "16px",
+        large: fontSizes["lg"],
+    },
+    fontWeights: {
+        body: "400",
+        heading: "700",
+        bold: "700",
+    },
+    lineHeights: {
+        heading: lineHeights.tight,
+        body: lineHeights.normal,
     },
     // Default styles
     styles: {},

--- a/siimple/index.js
+++ b/siimple/index.js
@@ -134,6 +134,7 @@ export const mergeStyles = (source, target) => {
         // Other value --> override source property
         source[key] = target[key];
     });
+    return source;
 };
 
 // Wrap CSS Rule

--- a/siimple/index.js
+++ b/siimple/index.js
@@ -85,11 +85,10 @@ export const mergeConfig = (source, target) => ({
     ...source,
     ...target,
     prefix: target.prefix || source.prefix || "",
-    breakpoints: mergeObject(source.breakpoints, target.breakpoints || {}),
-    scales: mergeObject(source.scales || {}, target.scales || {}),
+    breakpoints: target.breakpoints || source.breakpoints || {},
     variants: mergeObject(source.variants || {}, target.variants || {}),
-    root: target.root || {},
-    styles: target.styles || {},
+    root: target.root || source.root || {},
+    styles: mergeStyles(source.styles || {}, target.styles || {}),
 });
 
 // Parse CSS property name
@@ -145,9 +144,9 @@ const wrapCssRule = (ruleName, ruleContent, separator) => {
 // Build css value
 export const buildCssValue = (property, value, config) => {
     const values = [value].flat(1);
-    if (config.scales && scales[property] && typeof values[0] === "string") {
+    if (scales[property] && typeof values[0] === "string") {
         const key = scales[property];
-        values[0] = config.scales[key]?.[values[0]] || values[0];
+        values[0] = config[key]?.[values[0]] || values[0];
     }
     return values.join(" ");
 };

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -12,19 +12,20 @@ title: Minimal and themeable CSS toolkit
 
 ```js
 import colors from "siimple/colors";
+import {fonts} from "siimple/theme";
 
 export default {
-    scales: {
-        colors: {
-            primary: colors.royal["500"],
-            secondary: colors.mint["500"],
-            text: colors.royal["800"],
-            fill: colors.royal["200"],
-            heading: colors.royal["600"],
-        },
-        fonts: {
-            heading: ["Nunito", "sans-serif"],
-        },
+    colors: {
+        primary: colors.royal["500"],
+        secondary: colors.mint["500"],
+        text: colors.royal["800"],
+        fill: colors.royal["200"],
+        heading: colors.royal["600"],
+    },
+    fonts: {
+        body: fonts.sans,
+        heading: ["Nunito", "sans-serif"],
+        monospace: ["monospace"],
     },
 };
 ```
@@ -45,11 +46,14 @@ export default {
 </div>
 </div>
 
-<Section title="With hand-crafted icons" link="/icons">
-    Now <b>siimple</b> comes with an open source icon webfont that can be used in web and mobile projects. 
+<Section title="With hand-crafted icons*" link="/presets/icons">
+    Now <b>siimple</b> comes with a preset for adding <b>Pure CSS icons</b> that can be used in web and mobile projects. 
     Made with <i className="icon-heart"></i>.
 </Section>
 <IconsGallery />
+<blockquote className="">
+    <b>*</b> You will need to install the <code>@siimple/preset-icons</code> package and enable icons in your configuration.
+</blockquote>
 
 <div className="has-mb-8 has-mt-12">
     <div className="title has-text-4xl has-weight-black">What people say about siimple?</div>

--- a/website/pages/index.mdx
+++ b/website/pages/index.mdx
@@ -46,14 +46,11 @@ export default {
 </div>
 </div>
 
-<Section title="With hand-crafted icons*" link="/presets/icons">
+<Section title="With hand-crafted icons" link="/presets/icons">
     Now <b>siimple</b> comes with a preset for adding <b>Pure CSS icons</b> that can be used in web and mobile projects. 
     Made with <i className="icon-heart"></i>.
 </Section>
 <IconsGallery />
-<blockquote className="">
-    <b>*</b> You will need to install the <code>@siimple/preset-icons</code> package and enable icons in your configuration.
-</blockquote>
 
 <div className="has-mb-8 has-mt-12">
     <div className="title has-text-4xl has-weight-black">What people say about siimple?</div>

--- a/website/src/navs/documentation.js
+++ b/website/src/navs/documentation.js
@@ -4,7 +4,7 @@ export const documentationNav = [
     {"group": "getting-started", "url": "/naming", "label": "Naming methodology"},
     {"group": "getting-started", "url": "/responsive", "label": "Responsive"},
     {"group": "customize", "url": "/configuration", "label": "Configuration"},
-    {"group": "customize", "url": "/scales", "label": "Scales"},
+    {"group": "customize", "url": "/scales", "label": "Theme Scales"},
     {"group": "customize", "url": "/variants", "label": "Variants"},
     {"group": "customize", "url": "/colors", "label": "Colors"},
     {"group": "elements", "url": "/elements/alert", "label": "Alert"},


### PR DESCRIPTION
This PR removes the `scales` field from the configuration and moves all theme scales to the first level of the configuration object. 

Now a configuration object will look like the following:

```js
import colors from "siimple/colors.js";

export default {
    useRootStyles: false,
    useBorderBox: true,
    useElements: true,
    prefix: "",
    colors: {
        primary: colors.blue["500"],
        secondary: colors.mint["600"],
        text: colors.gray["800"],
        background: "#ffffff",
    },
    fonts: {
        body: ["Roboto", "sans-serif"],
        heading: ["Montserrat", "sans-serif"],
        monospace: ["monospace"],
    },
};
```