### PR TITLE
Add mixins support to core package

### DIFF
--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -1,4 +1,4 @@
-import {buildMixin} from "../packages/core.js";
+import {buildMixin} from "../packages/core/index.js";
 
 describe("buildMixin", () => {
     const theme = {

--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -20,6 +20,7 @@ describe("buildMixin", () => {
     it("should apply styles defined in the mixin", () => {
         const initialStyles = {
             color: "white",
+            apply: "test.basic",
         };
         const finalStyles = buildMixin(initialStyles, theme);
         expect(finalStyles.color).toBe("black");

--- a/test/mixins.test.js
+++ b/test/mixins.test.js
@@ -1,0 +1,42 @@
+import {buildMixin} from "../packages/core.js";
+
+describe("buildMixin", () => {
+    const theme = {
+        test: {
+            "basic": {
+                color: "black",
+                display: "none"
+            },
+            "circular1": {
+                display: "none",
+                apply: "test.circular2",
+            },
+            "circular2": {
+                display: "block",
+                apply: "test.circular1",
+            },
+        },
+    };
+    it("should apply styles defined in the mixin", () => {
+        const initialStyles = {
+            color: "white",
+        };
+        const finalStyles = buildMixin(initialStyles, theme);
+        expect(finalStyles.color).toBe("black");
+        expect(finalStyles.display).toBe("none");
+    });
+    it("should throw an error if circular mixins are found", () => {
+        expect.assertions(1);
+        try {
+            const styles = {
+                display: "flex",
+                apply: "test.circular1",
+            };
+            buildMixin(styles, theme);
+        }
+        catch (error) {
+            const msg = "Circular mixins found: test.circular1->test.circular2->test.circular1"
+            expect(error.message).toBe(msg);
+        }
+    });
+});


### PR DESCRIPTION
This PR adds support for mixins in the `@siimple/core` package.