### PR TITLE
Move all runtime API to the core package

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -8,19 +8,19 @@ import CleanCSS from "clean-css";
 import through from "through2";
 import Vinyl from "vinyl";
 
-import buildSiimple from "./siimple/index.js";
+import {css} from "@siimple/core";
 
 // Build Siimple
 const siimple = () => {
     return through.obj((file, enc, callback) => {
         import(file.path)
-        .then(rawConfig => {
-            return buildSiimple(rawConfig.default);
-        })
-        .then(css => {
-            file.contents = new Buffer.from(css);
-            return callback(null, file);
-        });
+            .then(rawConfig => {
+                return css(rawConfig.default);
+            })
+            .then(result => {
+                file.contents = new Buffer.from(result);
+                return callback(null, file);
+            });
     });
 };
 
@@ -28,11 +28,11 @@ const siimple = () => {
 const minify = options => {
     return through.obj((file, enc, callback) => {
         const content = file.contents.toString() || "";
-        new CleanCSS(options).minify(content, (errors, css) => {
+        new CleanCSS(options).minify(content, (errors, result) => {
             if (errors) {
                 return callback(errors.join(" "));
             }
-            file.contents = new Buffer.from(css.styles);
+            file.contents = new Buffer.from(result.styles);
             return callback(null, file);
         });
     });

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -12,44 +12,42 @@ $ npm install --save @siimple/core
 
 ## API
 
-### buildStyles(styles, theme)
+### css(config)
 
-Given a `styles` object and a `theme` object, this method will generate a CSS string with the parsed styles using the provided theme.
+Given a [configuration object](https://www.siimple.xyz/configuration), this method will generate a CSS string with the parsed styles in `config.styles` and using the provided theme in the configuration object.
 
 ```js
-import {buildStyles} from "@siimple/core";
+import {css} from "@siimple/core";
 
-// Example theme
-const theme = {
+const result = css({
+    useBorderBox: false,
+    useRootStyles: false,
     colors: {
-        text: "#000",
-        background: "#fff",
+        primary: "#34dde5",
     },
-};
-
-// Styles to compile
-const styles = {
-    html: {
-        backgroundColor: "background",
-        color: "text",
+    styles: {
+        button: {
+            backgroundColor: "primary",
+            color: "white",
+            p: "2rem",
+        },
     },
-};
-
-const css = buildStyles(styles, theme);
+});
 ```
 
 This will generate the following CSS string:
 
 ```css
-html {
-    background-color: #fff;
-    color: #000;
+button {
+    background-color: #34dde5;
+    color: white;
+    padding: 2rem;
 }
 ```
 
 ### mergeStyles(source, target)
 
-Performs a **deep merge** of the styles defined in the `target` object into `source`, and returns the merged styles.
+Performs a **deep merge** of the styles defined in the `target` object into the `source` object, and returns the merged styles object.
 
 ```js
 import {mergeStyles} from "@siimple/core";
@@ -91,6 +89,16 @@ mergedStyles = {
         },
     },
 };
+```
+
+### mergeConfig(source, target)
+
+This function will return a new configuration object as a result of performing a **deep merge** of the `target` configuration object into `source`.
+
+```js
+import {mergeConfig} from "@siimple/core";
+
+const config = mergeConfig({ /* source */}, {/* target */});
 ```
 
 

--- a/playground/src/worker.js
+++ b/playground/src/worker.js
@@ -1,4 +1,4 @@
-import siimple from "siimple";
+import {css} from "@siimple/core";
 import colors from "@siimple/colors";
 import reboot from "@siimple/preset-reboot";
 import elements from "@siimple/preset-elements";
@@ -51,13 +51,13 @@ self.addEventListener("message", event => {
         });
     }
     evaluateConfig(event.data.config)
-        .then(config => siimple(config))
-        .then(css => {
+        .then(config => css(config))
+        .then(result => {
             prevConfig = event.data.config;
-            prevCss = css;
+            prevCss = result;
             return self.postMessage({
                 id: event.data.id,
-                css: css,
+                css: result,
             });
         })
         .catch(error => {

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -21,7 +21,7 @@ module.exports = {
             path.resolve(__dirname, "./node_modules"),
         ],
         alias: {
-            "siimple": path.resolve(__dirname, "../siimple/"),
+            // "siimple": path.resolve(__dirname, "../siimple/"),
             "@siimple/colors": path.resolve(__dirname, "../packages/colors/"),
             "@siimple/core": path.resolve(__dirname, "../packages/core/"),
             "@siimple/preset-reboot": path.resolve(__dirname, "../packages/preset-reboot/"),

--- a/siimple/cli.js
+++ b/siimple/cli.js
@@ -3,7 +3,7 @@
 import fs from "fs";
 import path from "path";
 
-import build from "./index.js";
+import {css} from "@siimple/core";
 
 // Get CLI arguments
 const getArguments = () => {
@@ -35,15 +35,15 @@ process.nextTick(() => {
     }
     // Import configuration
     return resolveConfig(configPath).then(config => {
-        return build(config);
-    }).then(css => {
+        return css(config);
+    }).then(result => {
         // Print file in stdout
         if (!args.output) {
-            return process.stdout.write(css);
+            return process.stdout.write(result);
         }
         // Save to file
         const outputPath = path.resolve(process.cwd(), args.output);
-        fs.writeFileSync(outputPath, css, "utf8");
+        fs.writeFileSync(outputPath, result, "utf8");
     }).catch(error => {
         console.error(error);
         process.exit(1);

--- a/siimple/index.js
+++ b/siimple/index.js
@@ -1,31 +1,3 @@
-import {buildStyles, mergeConfig, mergeStyles} from "@siimple/core";
-
-// Build siimple
-export default config => {
-    const styles = {};
-    return new Promise(resolve => {
-        // Add borderbox styles
-        if (config.useBorderBox) {
-            mergeStyles(styles, {
-                html: {
-                    boxSizing: "border-box",
-                },
-                "*,*:before,*:after": {
-                    boxSizing: "inherit",
-                }
-            });
-        }
-        // Add root styles
-        if (config.useRootStyles) {
-            mergeStyles(styles, {
-                html: config.root || {},
-            });
-        }
-        // Add custom styles
-        if (config.styles) {
-            mergeStyles(styles, config.styles);
-        }
-        // Build and return css
-        return resolve(buildStyles(styles, config));
-    });
-};
+// Just export the same API from @siimple/core
+export {css} from "@siimple/core";
+export {mergeConfig, mergeStyles} from "@siimple/core";

--- a/siimple/index.js
+++ b/siimple/index.js
@@ -1,3 +1,12 @@
-// Just export the same API from @siimple/core
-export {css} from "@siimple/core";
-export {mergeConfig, mergeStyles} from "@siimple/core";
+// Export the same API from @siimple/core
+export {css, mergeConfig, mergeStyles} from "@siimple/core";
+
+// Export default theme
+export {default as theme} from "@siimple/preset-theme";
+
+// Export core presets
+export {default as reboot} from "@siimple/preset-reboot";
+export {default as elements} from "@siimple/preset-elements";
+export {default as helpers} from "@siimple/preset-helpers";
+export {default as markup} from "@siimple/preset-markup";
+export {default as icons} from "@siimple/preset-icons";

--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -13,7 +13,7 @@ exports.onCreateWebpackConfig = ({getConfig, plugins, actions}) => {
                 path.resolve(__dirname, "./node_modules"),
             ],
             "alias": {
-                "siimple": path.resolve(__dirname, "../siimple/"),
+                // "siimple": path.resolve(__dirname, "../siimple/"),
                 "@siimple/colors": path.resolve(__dirname, "../packages/colors/"),
                 "@siimple/preset-icons": path.resolve(__dirname, "../packages/preset-icons/"),
             },


### PR DESCRIPTION
This PR simplifies the API of the **siimple** main package and moves all the runtime API to the `@siimple/core` package.