### PR TITLE
fixed navbar typo doc

### DIFF
--- a/docs/recipes/navbar.mdx
+++ b/docs/recipes/navbar.mdx
@@ -15,7 +15,7 @@ title: Navbar
     <!-- Toggler button: only visible in mobile screens -->
     <div id="navbar-toggler" class="menu is-hidden-tablet"></div>
     <!-- Navigation menu: by default hidden on mobile screens -->
-    <div id="navbar-menu" class="is-flex-mobile has-w-full-mobile has-direction-column-mobile has-mt-4-mobile is-hidden-mobile">
+    <div id="navbar-menu" class="is-flex-tablet has-w-full-mobile has-direction-column-mobile has-mt-4-mobile is-hidden-mobile">
         <a class="navlink has-mb-2-mobile">Link 1</a>
         <a class="navlink">Link 2</a>
     </div>


### PR DESCRIPTION
This PR resolved the typo in the `navbar` example code https://siimple.xyz/recipes/navbar