### PR TITLE
feat: allow using CSS variables for scale values

### DIFF
--- a/packages/core/index.js
+++ b/packages/core/index.js
@@ -69,6 +69,12 @@ const aliases = {
     size: ["width", "height"],
 };
 
+// Map for css variables names
+const cssVariablesNames = {
+    colors: "color",
+    fonts: "font",
+};
+
 // Merge two object
 const mergeObject = (source, target) => ({...source, ...target});
 
@@ -111,7 +117,7 @@ const parseProperty = prop => {
 
 // Generate CSS variable name
 const getCssVariable = (scale, key) => {
-    return `--siimple-${parseProperty(scale)}-${parseProperty(key)}`;
+    return `--siimple-${cssVariablesNames[scale]}-${parseProperty(key)}`;
 };
 
 // Build CSS variables from scales
@@ -173,7 +179,7 @@ export const buildValue = (property, value, config, vars) => {
         const key = scales[property];
         if (config[key]?.[values[0]]) {
             // only colors and fonts are allowed to generate css variables
-            if (config.useCssVariables && (key === "colors" || key === "fonts")) {
+            if (config.useCssVariables && cssVariablesNames[key]) {
                 values[0] = `var(${getCssVariable(key, values[0])})`;
             }
             else {
@@ -304,8 +310,8 @@ export const buildStyles = (styles, config) => {
         });
     });
     if (config.useCssVariables) {
-        ["fonts", "colors"].filter(n => !!config[n]).forEach(name => {
-            const variables = buildCssVariables(name, config[name]);
+        Object.keys(cssVariablesNames).filter(s => !!config[s]).forEach(scale => {
+            const variables = buildCssVariables(cssVariablesNames[scale], config[scale], []);
             result.unshift(wrapRule(":root", variables.flat().join(""), ""));
         });
     }

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -1,4 +1,9 @@
-import {buildValue, buildRule, buildStyles} from "../packages/core/index.js";
+import {
+    buildValue,
+    buildRule,
+    buildStyles,
+    buildVariables,
+} from "../packages/core/index.js";
 
 describe("buildValue", () => {
     it("should return the same string value", () => {
@@ -135,8 +140,10 @@ describe("buildStyles", () => {
         }, {}).split("\n");
         expect(css[0]).toBe(":root {--variable1:#ffffff;--variable2:#000000;}");
     });
+});
 
-    it("should add scales as CSS variables if useCssVariables flag is enabled", () => {
+describe("buildVariables", () => {
+    it("should generate CSS variables from scale values", () => {
         const config = {
             useCssVariables: true,
             colors: {
@@ -149,10 +156,10 @@ describe("buildStyles", () => {
             },
             fontSizes: [0, 1, 2],
         };
-        const css = buildStyles({}, config).split("\n");
+        const css = buildVariables(config).split("\n");
         expect(css).toHaveLength(2);
-        expect(css[0]).toBe(":root {--siimple-font-body:font1;--siimple-font-code:font2;}");
-        expect(css[1]).toBe(":root {--siimple-color-primary:blue;--siimple-color-secondary:red;}");
+        expect(css[0]).toBe(":root {--siimple-color-primary:blue;--siimple-color-secondary:red;}");
+        expect(css[1]).toBe(":root {--siimple-font-body:font1;--siimple-font-code:font2;}");
     });
 });
 

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -32,8 +32,8 @@ describe("buildValue", () => {
             },
             fontSizes: [0, 1],
         };
-        expect(buildValue("color", "primary", config)).toBe("var(--siimple-colors-primary)");
-        expect(buildValue("fontFamily", "body", config)).toBe("var(--siimple-fonts-body)");
+        expect(buildValue("color", "primary", config)).toBe("var(--siimple-color-primary)");
+        expect(buildValue("fontFamily", "body", config)).toBe("var(--siimple-font-body)");
         expect(buildValue("fontSize", "1", config)).toBe("1");
     });
 });
@@ -151,8 +151,8 @@ describe("buildStyles", () => {
         };
         const css = buildStyles({}, config).split("\n");
         expect(css).toHaveLength(2);
-        expect(css[0]).toBe(":root {--siimple-colors-primary:blue;--siimple-colors-secondary:red;}");
-        expect(css[1]).toBe(":root {--siimple-fonts-body:font1;--siimple-fonts-code:font2;}");
+        expect(css[0]).toBe(":root {--siimple-font-body:font1;--siimple-font-code:font2;}");
+        expect(css[1]).toBe(":root {--siimple-color-primary:blue;--siimple-color-secondary:red;}");
     });
 });
 

--- a/test/build.test.js
+++ b/test/build.test.js
@@ -11,6 +11,31 @@ describe("buildValue", () => {
         const value = buildValue("", ["5px", "10px"], {});
         expect(value).toBe("5px 10px");
     });
+
+    it ("should get the value from the specified scale", () => {
+        const value = buildValue("color", "primary", {
+            colors: {
+                primary: "blue",
+            },
+        });
+        expect(value).toBe("blue");
+    });
+
+    it("should use css variables if the useCssVariables flag is enabled", () => {
+        const config = {
+            useCssVariables: true,
+            colors: {
+                primary: "blue",
+            },
+            fonts: {
+                body: "font1",
+            },
+            fontSizes: [0, 1],
+        };
+        expect(buildValue("color", "primary", config)).toBe("var(--siimple-colors-primary)");
+        expect(buildValue("fontFamily", "body", config)).toBe("var(--siimple-fonts-body)");
+        expect(buildValue("fontSize", "1", config)).toBe("1");
+    });
 });
 
 describe("buildRule", () => {
@@ -109,6 +134,25 @@ describe("buildStyles", () => {
             }
         }, {}).split("\n");
         expect(css[0]).toBe(":root {--variable1:#ffffff;--variable2:#000000;}");
-    })
+    });
+
+    it("should add scales as CSS variables if useCssVariables flag is enabled", () => {
+        const config = {
+            useCssVariables: true,
+            colors: {
+                primary: "blue",
+                secondary: "red",
+            },
+            fonts: {
+                body: "font1",
+                code: "font2",
+            },
+            fontSizes: [0, 1, 2],
+        };
+        const css = buildStyles({}, config).split("\n");
+        expect(css).toHaveLength(2);
+        expect(css[0]).toBe(":root {--siimple-colors-primary:blue;--siimple-colors-secondary:red;}");
+        expect(css[1]).toBe(":root {--siimple-fonts-body:font1;--siimple-fonts-code:font2;}");
+    });
 });
 


### PR DESCRIPTION
This PR allows using [CSS variables](https://developer.mozilla.org/en-US/docs/Web/CSS/Using_CSS_custom_properties) to store scale values defined in the configuration of siimple.