### PR TITLE
feat: new standalone package

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -102,3 +102,42 @@ You can also use [unpkg](https://unpkg.com/) for including the latest version in
 <link rel="stylesheet" href="https://unpkg.com/siimple/siimple.css" />
 ```
 
+### Standalone (experimental)
+
+> **Note**: this is still in experimental mode and API may change at any moment. **Please do not use it in production**.
+
+You can use the `@siimple/standalone` package to build your siimple configuration directly in the browser.
+
+The simplest way to include `@siimple/standalone` in a browser without any other setup is to use **unpkg**:
+
+```html
+<script src="https://unpkg.com/@siimple/standalone/siimple-standalone.js"></script>
+```
+
+You can alternatively add it in your project using **npm** or **yarn**:
+
+```bash
+$ npm install --save @siimple/standalone
+```
+
+After loading the `@siimple/standalone` package in the browser, it will automatically compile the configuration provided in a `<script>` tag with type `text/siimple` and include the output CSS in a `<style>` tag.
+
+```html
+<!-- Load @siimple/standalone -->
+<script src="https://unpkg.com/@siimple/standalone/siimple-standalone.js"></script>
+
+<!-- Your custom configuration there -->
+<script type="text/siimple">
+    export default {
+        // ...your configuration
+    };
+</script>   
+```
+
+You can provide your configuration as an external script:
+
+```html
+<script type="text/siimple" src="theme.js"></script>
+```
+
+Read more about the [standalone package](/packages/standalone).

--- a/docs/packages/standalone.mdx
+++ b/docs/packages/standalone.mdx
@@ -1,0 +1,7 @@
+---
+title: Standalone
+---
+
+import Readme from "../../packages/standalone/README.md";
+
+<Readme />

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -1,8 +1,8 @@
 # @siimple/standalone
 
-Standalone build of **siimple** for use in browser.
+Standalone build of **siimple** for use directly in browser.
 
-> **Note**: this is an experimental package. API may change at any time.
+> **Note**: this is an experimental package. API may change at any time. **Please do not use it in production**.
 
 ## Installation
 
@@ -61,32 +61,16 @@ Example:
 <script type="text/javascript">
     Siimple.configure({
         cdnUrl: "https://unpkg.com/",
+        preventFlashOfUnstyledContent: true,
     });
 </script>
 ```
 
-### registerModule
+### registerExternal
 
-> Siimple.registerModule(name, obj)
+> Siimple.registerExternal(name, obj)
 
-Registers a new module to resolve in the configuration. The `name` argument is the module name (for example `@siimple/preset-base`) and `obj` is the object that will be returned im the `import` statement.
-
-### disableScriptTag
-
-Disables automatically convert the configuration provided in a `<script>` tag with the `type="text/siimple"` when page is loaded.
-
-Example:
-
-```html
-<!-- Load @siimple/standalone -->
-<script src="https://unpkg.com/@siimple/standalone/siimple-standalone.js"></script>
-
-<!-- Disable automatically generate siimple -->
-<script type="text/javascript">
-    Siimple.disableScriptTag();
-</script>
-``` 
-
+Registers a new external module to resolve in the configuration using the `import` statement. The `name` argument is the module name (for example `@siimple/preset-base`) and `obj` is the object that will be returned im the `import` statement.
 
 ## License
 

--- a/packages/standalone/README.md
+++ b/packages/standalone/README.md
@@ -1,0 +1,93 @@
+# @siimple/standalone
+
+Standalone build of **siimple** for use in browser.
+
+> **Note**: this is an experimental package. API may change at any time.
+
+## Installation
+
+Install this package using **npm**:
+
+```bash
+ npm install --save @siimple/standalone
+```
+
+Or include it directly in your HTML file from **unpkg**:
+
+```html
+<script src="https://unpkg.com/@siimple/standalone/siimple-standalone.js"></script>
+```
+
+## Usage
+
+When loaded in a browser, `@siimple/standalone` will automatically compile the configuration provided in a `<script>` tag with type `text/siimple` and include the output CSS in a `<style>` tag.
+
+```html
+<!-- Load @siimple/standalone -->
+<script src="https://unpkg.com/@siimple/standalone/siimple-standalone.js"></script>
+
+<!-- Your custom configuration there -->
+<script type="text/siimple">
+    export default {
+        // ...your configuration
+    };
+</script>   
+```
+
+You can provide your configuration as an external script:
+
+```html
+<script type="text/siimple" src="theme.js"></script>
+```
+
+## API
+
+### configure
+
+> Siimple.configure(options)
+
+Customize the behaviour of the siimple config parser and compiler. The following option are allowed:
+
+- `cdnUrl`: URL to use for resolving modules. Default is `"https://esm.sh/`.
+- `preventFlashOfUnstyledContent`: a boolean to prevetn the common [Flash of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content). Default is `true`.
+
+Example:
+
+```html
+<!-- Load @siimple/standalone -->
+<script src="https://unpkg.com/@siimple/standalone/siimple-standalone.js"></script>
+
+<!-- Disable automatically generate siimple -->
+<script type="text/javascript">
+    Siimple.configure({
+        cdnUrl: "https://unpkg.com/",
+    });
+</script>
+```
+
+### registerModule
+
+> Siimple.registerModule(name, obj)
+
+Registers a new module to resolve in the configuration. The `name` argument is the module name (for example `@siimple/preset-base`) and `obj` is the object that will be returned im the `import` statement.
+
+### disableScriptTag
+
+Disables automatically convert the configuration provided in a `<script>` tag with the `type="text/siimple"` when page is loaded.
+
+Example:
+
+```html
+<!-- Load @siimple/standalone -->
+<script src="https://unpkg.com/@siimple/standalone/siimple-standalone.js"></script>
+
+<!-- Disable automatically generate siimple -->
+<script type="text/javascript">
+    Siimple.disableScriptTag();
+</script>
+``` 
+
+
+## License
+
+[MIT License](https://github.com/jmjuanes/siimple/blob/main/LICENSE).

--- a/packages/standalone/index.js
+++ b/packages/standalone/index.js
@@ -25,8 +25,8 @@ export const configure = newOptions => {
     Object.assign(globalOptions, newOptions || {});
 };
 
-// Register a new module
-export const registerModule = (moduleName, moduleObj) => {
+// Register a new external module
+export const registerExternal = (moduleName, moduleObj) => {
     modulesCache.set(moduleName, moduleObj);
 };
 
@@ -147,8 +147,8 @@ const onDOMContentLoaded = () => {
     log(` --> Documentation for siimple/standalone is available at ${DOCS_URL}.`);
     log(" --> Please do not use it in production environments.");
     if (globalOptions.preventFlashOfUnstyledContent) {
-        // document.body.style.display = "none";
         getStyleTag(STYLES_INTERNAL).innerHTML = ".__unstyled { display: none; }";
+        document.body.classList.add("__unstyled");
     }
     buildFromScriptTag();
 };

--- a/packages/standalone/index.js
+++ b/packages/standalone/index.js
@@ -1,0 +1,167 @@
+import {css as buildCss} from "@siimple/core";
+import {injectModules} from "@siimple/modules";
+
+const ISSUES_URL = "https://github.com/jmjuanes/siimple/issues";
+const DOCS_URL = "https://siimple.xyz/packages/standalone";
+
+const STYLES_INTERNAL = "standalone:internal";
+const STYLES_CSS = "standalone:css";
+
+// Global configuration
+const globalOptions = {
+    logger: console.warn,
+    cdnUrl: "https://esm.sh/",
+    preventFlashOfUnstyledContent: true,
+};
+
+const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+const log = msg => typeof globalOptions.logger === "function" && globalOptions.logger(`[siimple:standalone] ${msg}`);
+
+// Internal modules cache
+const modulesCache = new Map();
+
+// Configure
+export const configure = newOptions => {
+    Object.assign(globalOptions, newOptions || {});
+};
+
+// Register a new module
+export const registerModule = (moduleName, moduleObj) => {
+    modulesCache.set(moduleName, moduleObj);
+};
+
+// Inject unstyled class
+// See https://en.wikipedia.org/wiki/Flash_of_unstyled_content 
+const injectUnstyled = config => ({
+    ...config,
+    styles: {
+        ...(config?.styles || {}),
+        // If enabled, the <body> tag will have by default a display:none css applied
+        ".__unstyled": {
+            display: ["block", "!important"],
+        },
+    },
+});
+
+// Load the script file specified in the 'src' attribute
+const loadScript = url => {
+    return new Promise((resolve, reject) => {
+        const request = new XMLHttpRequest();
+        request.addEventListener("load", () => {
+            if (request.status > 299) {
+                return reject(new Error(`Unable to load '${url}'`));
+            }
+            return resolve(request.responseText);
+        });
+        request.addEventListener("error", reject);
+        request.overrideMimeType("text/plain");
+        request.open("get", url, true);
+        request.send(null);
+    });
+};
+
+const getStyleTag = id => {
+    let target = document.querySelector(`style[data-siimple="${id}"]`);
+    if (!target) {
+        target = document.createElement("style");
+        target.dataset.siimple = id;
+        document.head.appendChild(target);
+    }
+    return target;
+};
+
+// Evaluate configuration from string
+const evaluateConfig = configStr => {
+    return Promise.resolve().then(() => {
+        const configCode = configStr
+            // .replace(/import\s*(.*?)\s*from\s*(['"])@siimple\/(.*?)(\.js)?\2(;)?/g, `const $1 = _import("$3");`)
+            .replace(/import\s*(\{[\s\S]*?\})\s*from\s*(['"])([\w-@/]+)\2/g, `const $1 = await _import("$3");`)
+            .replace(/import\s*(.*?)\s*from\s*(['"])([\w-@/]+)\2/g, `const $1 = (await _import("$3")).default;`)
+            .replace(/export default /, "return ");
+        
+        // Custom import function
+        const _importFn = new Function("a", "return import(a);");
+        const _import = name => {
+            // Check if this module is cached
+            if (modulesCache.has(name)) {
+                return Promise.resolve(modulesCache.get(name));
+            }
+            // Import this module
+            const modulePath = globalOptions.cdnUrl + name;
+            return _importFn(modulePath).then(response => {
+                modulesCache.set(name, response);
+                return response;
+            });
+        };
+        const fn = new AsyncFunction("_import", configCode);
+        return fn(_import);
+    });
+};
+
+// Use the specified text as the configuration for siimple
+export const buildFromString = configString => {
+    return evaluateConfig(configString)
+        .then(config => injectModules(config))
+        .then(config => injectUnstyled(config))
+        .then(config => buildCss(config))
+        .then(cssString => {
+            getStyleTag(STYLES_CSS).innerHTML = cssString;
+            return true;
+        })
+};
+
+// Use the provided <script> tag to extract the siimple configuration and compile it.
+// If not provided, it will use the first <script> tag found in the document with the attribute type="text/siimple".
+export const buildFromScriptTag = selector => {
+    log("Starting siimple/standalone...");
+    const start = Date.now();
+    if (!selector) {
+        const items = document.querySelectorAll(`script[type="text/siimple"]`);
+        if (items.length === 0) {
+            log("No <script> tags found with the type='text/siimple' attribute found.");
+            return;
+        }
+        if (items.length > 1) {
+            log("Found multiple <script> tags with the type='text/siimple' attribute, but only the first will be processed.");
+        }
+        // Only use the first <script> tag found
+        selector = items[0];
+    }
+    // Load script content
+    return (selector.src ? loadScript(selector.src) : Promise.resolve(selector.innerHTML))
+        .then(str => buildFromString(str))
+        .then(() => {
+            const end = Date.now();
+            log(`Build finished after ${(end - start)}ms.`);
+        })
+        .catch(error => {
+            log("Something went wrong building siimple CSS");
+            log("You can find the error below. Please check first that your configuration code is correct.");
+            log(`If the problem persists, please open a new issue at ${ISSUES_URL}.`);
+            console.error(error);
+        });
+};
+
+const onDOMContentLoaded = () => {
+    log("Welcome to siimple/standalone");
+    log(` --> Documentation for siimple/standalone is available at ${DOCS_URL}.`);
+    log(" --> Please do not use it in production environments.");
+    if (globalOptions.preventFlashOfUnstyledContent) {
+        // document.body.style.display = "none";
+        getStyleTag(STYLES_INTERNAL).innerHTML = ".__unstyled { display: none; }";
+    }
+    buildFromScriptTag();
+};
+
+// Automatically process the first <script> tag with the type="text/siimple" attribute
+if (typeof window !== "undefined" && window?.addEventListener) {
+    window.addEventListener("DOMContentLoaded", onDOMContentLoaded, false);
+}
+
+// Disable the automatic transform of <script> tags with the type="text/siimple" attribute
+export const disableScriptTag = () => {
+    window.removeEventListener("DOMContentLoaded", onDOMContentLoaded);
+};
+
+// Reload siimple (just call again the buildFromScriptTag)
+export const reload = () => buildFromScriptTag();

--- a/packages/standalone/package.json
+++ b/packages/standalone/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@siimple/standalone",
+    "version": "0.3.0-beta",
+    "description": "Generate siimple CSS directly in your browser",
+    "author": "Josemi Juanes <josemi@siimple.xyz>",
+    "type": "module",
+    "license": "MIT",
+    "repository": "https://github.com/jmjuanes/siimple",
+    "bugs": "https://github.com/jmjuanes/siimple/issues",
+    "homepage": "https://www.siimple.xyz",
+    "main": "siimple-standalone.js",
+    "keywords": [
+        "siimple",
+        "css",
+        "browser"
+    ],
+    "files": [
+        "index.js",
+        "siimple-standalone.js",
+        "README.md"
+    ]
+}

--- a/test/standalone.test.js
+++ b/test/standalone.test.js
@@ -1,0 +1,36 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {buildFromString, buildFromScriptTag, configure} from "@siimple/standalone/index.js";
+
+// Disable logger
+configure({
+    logger: () => null,
+});
+
+const selector = `style[data-siimple="standalone:css"]`;
+
+describe("buildFromString", () => {
+    it("should append a new <style> element with the output css", () => {
+        const configStr = "export default {};";
+
+        return buildFromString(configStr).then(() => {
+            expect(document.querySelector(selector)).not.toBeNull();
+            expect(document.querySelector(selector).innerHTML).toEqual(expect.stringContaining(".button"));
+        });
+    });
+});
+
+describe("buildFromScriptTag", () => {
+    it("should load the content of the script tag", () => {
+        const script = document.createElement("script");
+        script.setAttribute("type", "text/siimple");
+        script.innerHTML = "export default {};";
+
+        buildFromScriptTag(script).then(() => {
+            expect(document.querySelector(selector)).not.toBeNull();
+            expect(document.querySelector(selector).innerHTML).toEqual(expect.stringContaining(".button"));
+        });
+    });
+});


### PR DESCRIPTION
This PR adds a new `@siimple/standalone` package for running **siimple** directly in the browser.