### PR TITLE
feat: add preset-dark

### DIFF
--- a/docs/presets/dark.mdx
+++ b/docs/presets/dark.mdx
@@ -1,0 +1,12 @@
+---
+title: Preset dark
+---
+
+import theme from "@siimple/preset-dark";
+import Readme from "@siimple/preset-dark/README.md";
+
+<Readme />
+
+## Demo
+
+<Preset theme={theme} />

--- a/packages/preset-dark/README.md
+++ b/packages/preset-dark/README.md
@@ -1,0 +1,24 @@
+# @siimple/preset-dark
+
+A dark theme preset for the **siimple CSS toolkit**. You can use this preset as a starting point for building your own dark theme for **siimple**.
+
+## Install
+
+Add this preset to your project using **npm** or **yarn**:
+
+```bash
+$ npm install --save @siimple/preset-dark
+```
+
+## Usage
+
+Include this preset in your `siimple.config.js` file:
+
+```js
+import dark from "@siimple/preset-dark";
+
+export default {
+    ...dark,
+    // ...other configuration
+};
+```

--- a/packages/preset-dark/index.js
+++ b/packages/preset-dark/index.js
@@ -1,0 +1,17 @@
+import colors from "@siimple/colors";
+import base from "@siimple/preset-base";
+
+export default {
+    ...base,
+    colors: {
+        primary: colors.blue["500"],
+        secondary: colors.royal["500"],
+        highlight: colors.blue["700"],
+        muted: colors.gray["700"],
+        text: "#fff",
+        heading: "#fff",
+        background: colors.gray["900"],
+        dark: colors.gray["900"],
+        white: "#fff",
+    },
+};

--- a/packages/preset-dark/package.json
+++ b/packages/preset-dark/package.json
@@ -1,0 +1,22 @@
+{
+    "name": "@siimple/preset-dark",
+    "version": "0.3.0-beta",
+    "description": "Dark theme preset for the siimple css toolkit",
+    "author": "Josemi Juanes <josemi@siimple.xyz>",
+    "type": "module",
+    "license": "MIT",
+    "repository": "https://github.com/jmjuanes/siimple",
+    "bugs": "https://github.com/jmjuanes/siimple/issues",
+    "homepage": "https://www.siimple.xyz/presets/dark",
+    "main": "index.js",
+    "dependencies": {
+        "@siimple/colors": "^0.2.3",
+        "@siimple/preset-base": "^0.2.3"
+    },
+    "keywords": [
+        "siimple",
+        "preset",
+        "theme",
+        "dark"
+    ]
+}

--- a/website/sidebar.js
+++ b/website/sidebar.js
@@ -226,6 +226,11 @@ export const sidebarItems = [
     },
     {
         group: "presets",
+        url: "/presets/dark",
+        label: "@siimple/perset-dark",
+    },
+    {
+        group: "presets",
         url: "/presets/ice",
         label: "preset-ice",
     },


### PR DESCRIPTION
This PR adds a new `@siimple/preset-dark` package with a dark theme for siimple.