### PR TITLE
fix: deprecate some elements and moved as markup styles

### DIFF
--- a/docs/markup.mdx
+++ b/docs/markup.mdx
@@ -4,7 +4,7 @@ title: Markup
 
 # Markup
 
-this module provides base classes for styling common markup elements like `<h1>`, `<blockquote>` or `<p>`.
+This module provides base classes for styling common markup elements like `<h1>`, `<blockquote>` or `<p>`.
 
 ### Disable markup module
 

--- a/docs/markup.mdx
+++ b/docs/markup.mdx
@@ -2,10 +2,9 @@
 title: Markup
 ---
 
-
 # Markup
 
-this module provides base classes for styling markup elements like `<h1>`, `<blockquote>` or `<p>`.
+this module provides base classes for styling common markup elements like `<h1>`, `<blockquote>` or `<p>`.
 
 ### Disable markup module
 
@@ -20,11 +19,28 @@ export default {
 };
 ```
 
-### Usage
+### Customize markup elements
+
+Use the `styles` field of your theme configuration to style markup elements. As an example, you can customize link elements (`<a>`) just adding your custom styles in the `styles.a` section of your configuration:
+
+```js title=siimple.config.js
+export default {
+    // ...other configuration
+    styles: {
+        a: {
+            color: "secondary",
+            textDecoration: "underline",
+        },
+        // ...other styles
+    },
+};
+```
+
+### Using markup styles
 
 #### Headings
 
-This module includes styles for your heading elements, from `<h1>` through `<h6>`. Headings will reuse styles defined in the `text.heading` field of your theme configuration.
+This module includes styles for your heading tags, from `<h1>` through `<h6>`.
 
 ```html live=true
 <h1>h1. Siimple heading</h1>
@@ -35,9 +51,30 @@ This module includes styles for your heading elements, from `<h1>` through `<h6>
 <h6>h6. Siimple heading</h6>
 ```
 
+Headings can be customized using `styles.h1` through `styles.h6`. You can customize all the common properties of the headings using the `text.heading` field of your theme configuration:
+
+```js title=siimple.config.js
+export default {
+    // ...other configuration
+    text: {
+        // The following styles will be applied to all heading tags,
+        // from <h1> through <h6>
+        heading: {
+            marginBottom: "2rem",
+        },
+    },
+    styles: {
+        // Customize individual heading tags
+        h1: {
+            marginTop: "0px",
+        },
+    },
+}
+```
+
 #### Paragraph
 
-This module includes styles for your `<p>` elements. Paragraphs will reuse styles defined in the `text.paragraph` field of your theme configuration.
+This module includes styles for your paragraph tags (`<p>`):
 
 ```html live=true
 <p class="has-mb-none">
@@ -46,9 +83,22 @@ This module includes styles for your `<p>` elements. Paragraphs will reuse style
 </p>
 ```
 
+Paragraphs can be customized using the `styles.p` field of your theme configuration: 
+
+```js title="siimple.config.js"
+export default {
+    // ...other configuration
+    styles: {
+        p: {
+            marginBottom: "1.5rem",
+        },
+    },
+};
+```
+
 #### Blockquotes
 
-This module includes styles for your `<blockquote>` elements:
+This module includes styles for your quote tags (`<blockquote>`):
 
 ```html live=true
 <blockquote>
@@ -57,35 +107,136 @@ This module includes styles for your `<blockquote>` elements:
 </blockquote>
 ```
 
+Blockquotes can be customized using the `styles.blockquote` field of your theme configuration:
+
+```js title="siimple.config.js"
+export default {
+    // ...other configuration
+    styles: {
+        blockquote: {
+            marginBottom: "1.5rem",
+        },
+    },
+};
+```
+
 #### Inline links
 
-This module includes styles for your inline links elements. Links will reuse styles defined in the `text.link` field of your theme configuration.
+This module includes styles for your inline link tags (`<a>`).
 
 ```html live=true
 You can style your <a href="">link</a> elements.
 ``` 
 
+Inline links can be customized using the `styles.a` field of your theme configuration:
+
+```js title="siimple.config.js"
+export default {
+    // ...other configuration
+    styles: {
+        a: {
+            color: "primary",
+            textTransform: "underline",
+        },
+        // ...other styles
+    },
+};
+```
+
 #### Small text
 
-This module adds styles for your `<small>` elements, and reuse styles defined in the `text.small` field of your theme configuration.
+This module adds styles for your `<small>` tags:
 
 ```html live=true
 You can style your <small>small text</small> elements.
 ```
 
+Small text tags can be customized using the `styles.small` field of your theme configuration:
+
+```js title="siimple.config.js"
+export default {
+    // ...other configuration
+    styles: {
+        small: {
+            color: "muted",
+            fontSize: "0",
+        },
+        // ...other styles
+    },
+};
+```
+
 #### Inline code
 
-This module includes styles for your inline code elements, and will reuse styles defined in the `text.code` field of your theme configuration.
+This module includes styles for your inline code tags (`<code>`):
 
 ```html live=true
 You can style your <code>inline code</code> elements.
 ```
 
+Inline code tags can be customized using the `styles.code` field of your theme configuration: 
+
+```js title="siimple.config.js"
+export default {
+    // ...other configuration
+    styles: {
+        code: {
+            color: "secondary",
+        },
+        // ...other styles
+    },
+};
+```
+
 #### Horizontal rule
 
-This module includes styles for your `<hr>` elements: 
+This module includes styles for your horizontal rule tags (`<hr>`): 
 
-```html
+```html live=true
 <hr>
 ```
 
+Horizontal rule tags can be customized using the `styles.hr` field of your theme configuration: 
+
+```js title="siimple.config.js"
+export default {
+    // ...other configuration
+    styles: {
+        hr: {
+            marginBottom: "1rem",
+            marginTop: "1rem",
+        },
+    },
+};
+```
+
+#### Tables
+
+This module includes styles for your table tags (`<table>`) and all of its child tags (`<tr>`, `<td>`, `<th>`, `<thead>` and `<tbody>`).
+
+| Header 1 | Header 2 | Header 3 |
+|----------|----------|----------|
+| Cell 1   | Cell 2   | Cell 3   |
+| Cell 4   | Cell 5   | Cell 6   |
+
+```html
+<table>
+    ...
+</table>
+```
+
+Table tags and its child subtags can be customized using the `styles.table` field of your theme configuration.
+
+```js title=siimple.config.js
+export default {
+    styles: {
+        table: {
+            "& th, & td": {
+                backgroundColor: "white",
+                padding: "1rem",
+            },
+        },
+    },
+    // ...other configuration
+};
+```

--- a/packages/modules/elements.js
+++ b/packages/modules/elements.js
@@ -216,7 +216,7 @@ export const elements = {
         type: "div",
         displayName: "Column",
         styles: {
-            apply: "columns.default",
+            apply: "layout.column",
             flex: "1",
             minHeight: "0",
             padding: "1rem",
@@ -235,14 +235,12 @@ export const elements = {
                 return [`&.is-${column}`, styles];
             })),
         },
-        variants: "columns",
-        defaultVariants: {},
     },
     columns: {
         type: "div",
         displayName: "Columns",
         styles: {
-            // apply: "layout.columns",
+            apply: "layout.columns",
             display: "flex",
             flexWrap: "wrap",
             marginLeft: "-1rem",

--- a/packages/modules/elements.js
+++ b/packages/modules/elements.js
@@ -216,7 +216,7 @@ export const elements = {
         type: "div",
         displayName: "Column",
         styles: {
-            apply: "layout.column",
+            apply: "columns.default",
             flex: "1",
             minHeight: "0",
             padding: "1rem",
@@ -235,12 +235,14 @@ export const elements = {
                 return [`&.is-${column}`, styles];
             })),
         },
+        variants: "columns",
+        defaultVariants: {},
     },
     columns: {
         type: "div",
         displayName: "Columns",
         styles: {
-            apply: "layout.columns",
+            // apply: "layout.columns",
             display: "flex",
             flexWrap: "wrap",
             marginLeft: "-1rem",
@@ -307,7 +309,7 @@ export const elements = {
         type: "div",
         displayName: "Crumbs",
         styles: {
-            apply: "links.crumbs",
+            // apply: "links.crumbs",
             borderRadius: "default",
             display: "flex",
             flexWrap: "nowrap",
@@ -316,24 +318,6 @@ export const elements = {
             overflowX: "auto",
             padding: "0.5rem",
             whiteSpace: ["nowrap", "!important"],
-        },
-    },
-    divider: {
-        type: "div",
-        displayName: "Divider",
-        styles: {
-            apply: "styles.hr",
-            backgroundColor: "muted",
-            border: "0px",
-            display: "block",
-            height: "0.125rem",
-            padding: "0px",
-            "&:not(:first-child)": {
-                marginTop: "1rem",
-            },
-            "&:not(:last-child)": {
-                marginBottom: "1rem",
-            },
         },
     },
     dropdown: {
@@ -486,20 +470,6 @@ export const elements = {
             "&.is-disabled": {
                 opacity: "0.5",
                 pointerEvents: "none",
-            },
-        },
-    },
-    paragraph: {
-        type: "p",
-        displayName: "Paragraph",
-        styles: {
-            apply: "text.paragraph",
-            display: "block",
-            marginBottom: "1rem",
-            marginTop: "0px",
-            "&.is-lead": {
-                fontSize: "2",
-                fontWeight: "bold",
             },
         },
     },
@@ -764,6 +734,70 @@ export const elements = {
             },
         },
     },
+    textarea: {
+        type: "textarea",
+        displayName: "Textarea",
+        styles: {
+            apply: "forms.textarea",
+            backgroundColor: "muted",
+            borderColor: "transparent",
+            borderStyle: "solid",
+            borderWidth: "0.125rem",
+            borderRadius: "0.5rem",
+            boxSizing: "border-box",
+            color: "inherit",
+            display: "block",
+            fontFamily: "inherit",
+            fontSize: "inherit",
+            lineHeight: "inherit",
+            margin: "0px",
+            minWidth: "0px",
+            outline: "0px",
+            padding: ["0.625rem", "1rem"],
+            resize: "vertical",
+            // verticalAlign: "top",
+            width: "100%",
+            "&:focus": {
+                borderColor: "primary",
+            },
+        },
+    },
+    // 
+    // DEPRECATED ELEMENTS: TO BE REMOVED IN THE NEXT MAJOR RELEASE
+    // USE MARKUP ELEMENTS INSTEAD
+    //
+    divider: {
+        type: "div",
+        displayName: "Divider",
+        styles: {
+            apply: "styles.hr",
+            backgroundColor: "muted",
+            border: "0px",
+            display: "block",
+            height: "0.125rem",
+            padding: "0px",
+            "&:not(:first-child)": {
+                marginTop: "1rem",
+            },
+            "&:not(:last-child)": {
+                marginBottom: "1rem",
+            },
+        },
+    },
+    paragraph: {
+        type: "p",
+        displayName: "Paragraph",
+        styles: {
+            apply: "text.paragraph",
+            display: "block",
+            marginBottom: "1rem",
+            marginTop: "0px",
+            "&.is-lead": {
+                fontSize: "2",
+                fontWeight: "bold",
+            },
+        },
+    },
     table: {
         type: "table",
         displayName: "Table",
@@ -804,18 +838,6 @@ export const elements = {
             "& tbody td": {
                 verticalAlign: "top",
             },
-            "& thead tr:first-child th:first-child": {
-                borderTopLeftRadius: "0.5rem",
-            },
-            "& thead tr:first-child th:last-child": {
-                borderTopRightRadius: "0.5rem",
-            },
-            "& tbody tr:last-child td:first-child": {
-               borderBottomLeftRadius: "0.5rem",
-            },
-            "& tbody tr:last-child td:last-child": {
-               borderBottomRightRadius: "0.5rem",
-            },
             "&.is-divided": {
                 "& thead th": {
                     borderBottomColor: "muted",
@@ -843,34 +865,6 @@ export const elements = {
             },
             "&.is-fixed": {
                 tableLayout: "fixed",
-            },
-        },
-    },
-    textarea: {
-        type: "textarea",
-        displayName: "Textarea",
-        styles: {
-            apply: "forms.textarea",
-            backgroundColor: "muted",
-            borderColor: "transparent",
-            borderStyle: "solid",
-            borderWidth: "0.125rem",
-            borderRadius: "0.5rem",
-            boxSizing: "border-box",
-            color: "inherit",
-            display: "block",
-            fontFamily: "inherit",
-            fontSize: "inherit",
-            lineHeight: "inherit",
-            margin: "0px",
-            minWidth: "0px",
-            outline: "0px",
-            padding: ["0.625rem", "1rem"],
-            resize: "vertical",
-            // verticalAlign: "top",
-            width: "100%",
-            "&:focus": {
-                borderColor: "primary",
             },
         },
     },

--- a/packages/modules/elements.js
+++ b/packages/modules/elements.js
@@ -117,10 +117,10 @@ export const elements = {
             padding: "2rem",
             textDecoration: ["none", "!important"],
             width: "100%",
-            apply: "cards.default",
+            apply: "layout.card",
         },
-        variants: "cards",
-        defaultVariants: {},
+        // variants: "cards",
+        // defaultVariants: {},
     },
     checkbox: {
         type: "input",

--- a/packages/modules/markup.js
+++ b/packages/modules/markup.js
@@ -61,16 +61,58 @@ export const markup = {
         paddingTop: "0.75rem",
     },
     table: {
+        backgroundColor: "transparent",
+        borderCollapse: "separate",
+        borderSpacing: "0",
+        borderWidth: "0px",
+        boxSizing: "border-box",
+        display: "table",
+        marginBottom: "2rem",
         width: "100%",
+        "& tr": {
+            boxSizing: "border-box",
+            display: "table-row",
+        },
+        "& th,& td": {
+            boxSizing: "border-box",
+            display: "table-cell",
+            lineHeight: "inherit",
+            padding: "1rem",
+        },
+        "& thead": {
+            boxSizing: "border-box",
+            display: "table-header-group",
+        },
+        "& thead th": {
+            borderBottomColor: "muted",
+            borderBottomStyle: "solid",
+            borderBottomWidth: "0.125rem",
+            fontWeight: "bold",
+            textAlign: "left",
+            verticalAlign: "bottom",
+        },
+        "& tbody": {
+            display: "table-row-group",
+            verticalAlign: "middle",
+        },
+        "& tbody td": {
+            borderTopColor: "muted",
+            borderTopStyle: "solid",
+            borderTopWidth: "0.125rem",
+            verticalAlign: "top",
+        },
     },
     ...Object.fromEntries([6,5,4,3,2,1].map(index => {
         const headingNumber = 7 - index;
         const headingConfig = {
             color: "heading",
+            display: "block",
             fontFamily: "heading",
             fontSize: `${index}`,
             fontWeight: "heading",
             lineHeight: "heading",
+            marginBottom: "0.5rem",
+            padding: "0px",
             apply: "text.heading",
         };
         return [`h${(headingNumber)}`, headingConfig];

--- a/packages/preset-mustard/index.js
+++ b/packages/preset-mustard/index.js
@@ -84,6 +84,9 @@ export default {
         modal: {
             apply: "bordered",
         },
+        scrim: {
+            backdropFilter: "blur(2px)",
+        },
     },
     links: {
         nav: {

--- a/packages/preset-mustard/index.js
+++ b/packages/preset-mustard/index.js
@@ -75,8 +75,8 @@ export default {
             },
         },
     },
-    cards: {
-        default: {
+    layout: {
+        card: {
             apply: "bordered",
         },
     },

--- a/packages/preset-noir/index.js
+++ b/packages/preset-noir/index.js
@@ -71,8 +71,8 @@ export default {
             },
         },
     },
-    cards: {
-        default: {
+    layout: {
+        card: {
             apply: "bordered",
             // backgroundColor: colors.white,
             boxShadow: ["none", "!important"],

--- a/test/__snapshots__/components.test.js.snap
+++ b/test/__snapshots__/components.test.js.snap
@@ -28,7 +28,7 @@ exports[`Icon should render 1`] = `
 
 exports[`Markup should render 1`] = `
 <h1
-  className="sii-1986486495"
+  className="sii-1440198707"
 >
   Hello world
 </h1>


### PR DESCRIPTION
This PR deprecates `title`, `table`, `paragraph` and `divider` elements and now are part of the markup module.